### PR TITLE
Be explicit about isnan namespace

### DIFF
--- a/arc4random.cc
+++ b/arc4random.cc
@@ -30,7 +30,7 @@ NAN_METHOD(node_arc4random_buf) {
         return;
     }
 
-    if (!node::Buffer::HasInstance(info[0]) || !info[1]->IsNumber() || isnan(info[1]->NumberValue()) || info[1]->IntegerValue() < 0 || info[1]->IntegerValue() > UINT32_MAX) {
+    if (!node::Buffer::HasInstance(info[0]) || !info[1]->IsNumber() || std::isnan(info[1]->NumberValue()) || info[1]->IntegerValue() < 0 || info[1]->IntegerValue() > UINT32_MAX) {
         Nan::ThrowTypeError("Wrong arguments");
         return;
     }
@@ -57,7 +57,7 @@ NAN_METHOD(node_arc4random_uniform) {
         return;
     }
 
-    if (!info[0]->IsNumber() || isnan(info[0]->NumberValue()) || info[0]->IntegerValue() < 0 || info[0]->IntegerValue() > UINT32_MAX) {
+    if (!info[0]->IsNumber() || std::isnan(info[0]->NumberValue()) || info[0]->IntegerValue() < 0 || info[0]->IntegerValue() > UINT32_MAX) {
         Nan::ThrowTypeError("Wrong arguments");
         return;
     }


### PR DESCRIPTION
Hello! 

 First, thanks for the binding, this is exactly what I need :).  When I try to build arc4random it's throwing build errors such as:

  CXX(target) Release/obj.target/arc4random/arc4random.o
../arc4random.cc: In function 'Nan::NAN_METHOD_RETURN_TYPE node_arc4random_buf(Nan::NAN_METHOD_ARGS_TYPE)':
../arc4random.cc:33:100: error: 'isnan' was not declared in this scope
     if (!node::Buffer::HasInstance(info[0]) || !info[1]->IsNumber() || isnan(info[1]->NumberValue()) || info[1]->IntegerValue() < 0 || info[1]->IntegerValue() > UIN
                                                                                                    ^
../arc4random.cc:33:100: note: suggested alternative:
In file included from /usr/include/c++/5/random:38:0,
                 from /usr/include/c++/5/bits/stl_algo.h:66,
                 from /usr/include/c++/5/algorithm:62,
                 from ../../nan/nan.h:52,
                 from ../arc4random.cc:4:
/usr/include/c++/5/cmath:641:5: note:   'std::isnan'
     isnan(_Tp __x)
     ^
../arc4random.cc: In function 'Nan::NAN_METHOD_RETURN_TYPE node_arc4random_uniform(Nan::NAN_METHOD_ARGS_TYPE)':
../arc4random.cc:60:61: error: 'isnan' was not declared in this scope
     if (!info[0]->IsNumber() || isnan(info[0]->NumberValue()) || info[0]->IntegerValue() < 0 || info[0]->IntegerValue() > UINT32_MAX) {
                                                             ^
../arc4random.cc:60:61: note: suggested alternative:
In file included from /usr/include/c++/5/random:38:0,
                 from /usr/include/c++/5/bits/stl_algo.h:66,
                 from /usr/include/c++/5/algorithm:62,
                 from ../../nan/nan.h:52,
                 from ../arc4random.cc:4:
/usr/include/c++/5/cmath:641:5: note:   'std::isnan'
     isnan(_Tp __x)
     ^

It looks like it's related to the version of C++ being built against:
https://stackoverflow.com/questions/39130040/cmath-hides-isnan-in-math-h-in-c14-c11